### PR TITLE
github-migration/python-2/bumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,23 @@
+[bumpversion]
+current_version = 0.3.0
+commit = True
+tag = True
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
+serialize = 
+	{major}.{minor}.{patch}-{stage}.{devnum}
+	{major}.{minor}.{patch}
+
+[bumpversion:part:stage]
+optional_value = stable
+first_value = stable
+values = 
+	alpha
+	beta
+	stable
+
+[bumpversion:part:devnum]
+
+[bumpversion:file:setup.py]
+search = version='{current_version}',
+replace = version='{new_version}',
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,16 @@
+* Version: x.x.x
+* Python: 2.7/3.4/3.5
+* OS: osx/linux/win
+
+
+### What was wrong?
+
+Please include any of the following that are applicable:
+
+* The code which produced the error
+* The full output of the error
+
+
+### How can it be fixed?
+
+Fill this section in if you know how this could or should be fixed.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### What was wrong?
+
+
+
+### How was it fixed?
+
+
+
+#### Cute Animal Picture
+
+![Cute animal picture]()

--- a/README.md
+++ b/README.md
@@ -6,8 +6,67 @@ A library for handling the encrypted keyfiles used to store ethereum private key
 ## Installation
 
 ```sh
-pip install ethereum-keyfile
+pip install eth-keyfile
 ```
+
+
+## Development
+
+```sh
+pip install -e . -r requirements-dev.txt
+```
+
+
+### Running the tests
+
+You can run the tests with:
+
+```sh
+py.test tests
+```
+
+Or you can install `tox` to run the full test suite.
+
+
+### Releasing
+
+Pandoc is required for transforming the markdown README to the proper format to
+render correctly on pypi.
+
+For Debian-like systems:
+
+```
+apt install pandoc
+```
+
+Or on OSX:
+
+```sh
+brew install pandoc
+```
+
+To release a new version:
+
+```sh
+bumpversion $$VERSION_PART_TO_BUMP$$
+git push && git push --tags
+make release
+```
+
+
+#### How to bumpversion
+
+The version format for this repo is `{major}.{minor}.{patch}` for stable, and
+`{major}.{minor}.{patch}-{stage}.{devnum}` for unstable (`stage` can be alpha or beta).
+
+To issue the next version in line, use bumpversion and specify which part to bump,
+like `bumpversion minor` or `bumpversion devnum`.
+
+If you are in a beta version, `bumpversion stage` will switch to a stable.
+
+To issue an unstable version when the current version is stable, specify the
+new version explicitly, like `bumpversion --new-version 4.0.0-alpha.1 devnum`
+
 
 ## Documentation
 

--- a/eth_keyfile/__init__.py
+++ b/eth_keyfile/__init__.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
 import pkg_resources
+import warnings
+import sys
 
 from eth_keyfile.keyfile import (  # noqa: F401
     load_keyfile,
@@ -10,4 +12,12 @@ from eth_keyfile.keyfile import (  # noqa: F401
 )
 
 
-__version__ = pkg_resources.get_distribution("ethereum-keyfile").version
+if sys.version_info.major < 3:
+    warnings.simplefilter('always', DeprecationWarning)
+    warnings.warn(DeprecationWarning(
+        "The `eth-keyfile` library is dropping support for Python 2.  Upgrade to Python 3."
+    ))
+    warnings.resetwarnings()
+
+
+__version__ = pkg_resources.get_distribution("eth-keyfile").version

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest>=3.2.2
 tox>=1.8.0
 flake8>=3.0.4
+bumpversion==0.5.3

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=0.5.0",
-        "eth-keys>=0.1.0-beta.1",
+        "eth-keys>=0.1.0-beta.2",
         "cytoolz>=0.8.2",
         "pycryptodome>=3.4.7",
     ],

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=0.5.0",
-        "eth-keys>=0.1.0-beta.2",
+        "eth-keys>=0.1.0-beta.3",
         "cytoolz>=0.8.2",
         "pycryptodome>=3.4.7",
     ],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ DIR = os.path.dirname(os.path.abspath(__file__))
 
 
 setup(
-    name='ethereum-keyfile',
+    name='eth-keyfile',
+    # *IMPORTANT*: Don't manually change the version here. Use the 'bumpversion' utility.
     version='0.3.0',
     description=(
         "A library for handling the encrypted keyfiles used to store ethereum "
@@ -21,11 +22,11 @@ setup(
     long_description_markdown_filename='README.md',
     author='Piper Merriam',
     author_email='pipermerriam@gmail.com',
-    url='https://github.com/pipermerriam/ethereum-keyfile',
+    url='https://github.com/ethereum/eth-keyfile',
     include_package_data=True,
     install_requires=[
-        "ethereum-utils>=0.4.0",
-        "ethereum-keys>=0.1.0-alpha.7",
+        "eth-utils>=0.5.0",
+        "eth-keys>=0.1.0-beta.1",
         "cytoolz>=0.8.2",
         "pycryptodome>=3.4.7",
     ],


### PR DESCRIPTION
* bumpversion
* python2 deprecation
* rename to `eth-keyfile`

![basset hound puppies2](https://user-images.githubusercontent.com/824194/33290477-0d20fac2-d380-11e7-90c6-158298b44f6b.jpg)
