### PR TITLE
Upgrade to eth-utils v1-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
   include:
   - python: "3.5"
     env: TOX_ENV=flake8
-  - python: "2.7"
-    env: TOX_ENV=py27
   - python: "3.4"
     env: TOX_ENV=py34
   - python: "3.5"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='https://github.com/ethereum/eth-keyfile',
     include_package_data=True,
     install_requires=[
-        "eth-utils>=0.7.3,<1.0.0",
+        "eth-utils>=1.0.0-beta.1,<2.0.0",
         "eth-keys>=0.1.0-beta.4,<1.0.0",
         "cytoolz>=0.9.0,<1.0.0",
         "pycryptodome>=3.4.7,<4.0.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{27,34,35,36}
+    py{34,35,36}
     flake8
 
 [flake8]
@@ -14,7 +14,6 @@ commands=
 deps =
     -r{toxinidir}/requirements-dev.txt
 basepython =
-    py27: python2.7
     py34: python3.4
     py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

`eth-account` wants to use `eth-keyfile` and `eth-utils` v1-beta at the same time.

### How was it fixed?

Bump this to use `eth-utils` v1-beta at a minimum. I thought about allowing ">=0.7.4,<2.0.0", but then it seems like we'd have to run the test suite against both major versions, and I was too lazy to do that.

We could maybe bump this release to 0.5. semver says nothing is considered stable anyway pre-v1, so this change doesn't technically require a bump to v1.

#### Cute Animal Picture

![Cute animal picture](https://i.pinimg.com/originals/e0/a1/06/e0a106c91e0bf42c4e55f21fff6835a1.jpg)