### PR TITLE
handle mixed-case keys in keyfiles

### DIFF
--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -7,7 +7,6 @@ from Crypto.Cipher import AES
 from Crypto.Protocol.KDF import scrypt
 from Crypto.Util import Counter
 
-
 from eth_keys import keys
 
 from eth_utils import (
@@ -15,9 +14,11 @@ from eth_utils import (
     decode_hex,
     encode_hex,
     int_to_big_endian,
+    is_dict,
     is_string,
     keccak,
     remove_0x_prefix,
+    to_dict,
 )
 
 
@@ -40,7 +41,8 @@ def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2", iteratio
         raise NotImplementedError("Not yet implemented")
 
 
-def decode_keyfile_json(keyfile_json, password):
+def decode_keyfile_json(raw_keyfile_json, password):
+    keyfile_json = normalize_keys(raw_keyfile_json)
     version = keyfile_json['version']
 
     if version == 3:
@@ -53,6 +55,22 @@ def extract_key_from_keyfile(path_or_file_obj, password):
     keyfile_json = load_keyfile(path_or_file_obj)
     private_key = decode_keyfile_json(keyfile_json, password)
     return private_key
+
+
+@to_dict
+def normalize_keys(keyfile_json):
+    for key, value in keyfile_json.items():
+        if is_string(key):
+            norm_key = key.lower()
+        else:
+            norm_key = key
+
+        if is_dict(value):
+            norm_value = normalize_keys(value)
+        else:
+            norm_value = value
+
+        yield norm_key, norm_value
 
 
 #

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 import json
 import os
 
+from cytoolz import (
+    assoc,
+)
+
 import pytest
 
 import eth_keyfile
@@ -13,10 +17,39 @@ FIXTURES_FILE_PATH = os.path.join(
     'basic_tests.json',
 )
 
+MEW_KEYFILE = {
+    'json': {
+        'Crypto': {
+            'cipher': 'aes-128-ctr',
+            'cipherparams': {
+                'iv': '7e7b02d2b4ef45d6c98cb885e75f48d5',
+            },
+            'ciphertext': 'a7a5743a6c7eb3fa52396bd3fd94043b79075aac3ccbae8e62d3af94db00397c',
+            'kdf': 'scrypt',
+            'kdfparams': {
+                'dklen': 32,
+                'n': 8192,
+                'p': 1,
+                'r': 8,
+                'salt': '247797c7a357b707a3bdbfaa55f4c553756bca09fec20ddc938e7636d21e4a20',
+            },
+            'mac': '5a3ba5bebfda2c384586eda5fcda9c8397d37c9b0cc347fea86525cf2ea3a468',
+        },
+        'address': '0b6f2de3dee015a95d3330dcb7baf8e08aa0112d',
+        'id': '3c8efdd6-d538-47ec-b241-36783d3418b9',
+        'version': 3,
+    },
+    'password': 'moomoocow',
+    'priv': '21eac69b9a52f466bfe9047f0f21c9caf3a5cdaadf84e2750a9b3265d450d481',
+}
+
 
 
 with open(FIXTURES_FILE_PATH) as fixtures_file:
-    KEYFILE_FIXTURES = json.load(fixtures_file)
+    BASE_KEYFILE_FIXTURES = json.load(fixtures_file)
+
+
+KEYFILE_FIXTURES = assoc(BASE_KEYFILE_FIXTURES, 'MEW_generated_keyfile', MEW_KEYFILE)
 
 
 @pytest.fixture(params=KEYFILE_FIXTURES.keys())

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands=
     py.test {posargs:tests}
 deps =
     -r{toxinidir}/requirements-dev.txt
+    py34: typing
 basepython =
     py34: python3.4
     py35: python3.5


### PR DESCRIPTION
Replaces #9 

Adds a key normalization step prior to attempting to decode a keyfile to ensure that all keys are lowercased.