### PR TITLE
Adds Travis badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Ethereum Keyfile
 
+[![Build Status](https://travis-ci.org/ethereum/eth-keyfile.svg?branch=master)](https://travis-ci.org/ethereum/eth-keyfile)
+
 A library for handling the encrypted keyfiles used to store ethereum private keys
 
 


### PR DESCRIPTION
### What was wrong?

The Travis badge is not showing in the README.md
I like seeing green Travis badge because it reassures me the project is actually tested and in a stable state.


### How was it fixed?

Thankfully Travis is already setup, so I just had to add the Badge


#### Cute Animal Picture

[From Reddit the other day](https://www.reddit.com/r/aww/comments/9qi356/our_cats_truly_love_each_other/?utm_content=comments&utm_medium=user&utm_source=reddit&utm_name=u_AndreMiras)
![image](https://user-images.githubusercontent.com/24973/47810101-bdff3800-dd42-11e8-8be5-96e953ee1702.png)
