### PR TITLE
Updates eth-keys upper boundary

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "eth-utils>=1.0.0-beta.1,<2.0.0",
-        "eth-keys>=0.1.0-beta.4,<1.0.0",
+        "eth-keys>=0.1.0-beta.4,<0.3.0",
         "cytoolz>=0.9.0,<1.0.0",
         "pycryptodome>=3.4.7,<4.0.0",
     ],


### PR DESCRIPTION
### What was wrong?
`eth-account` requires `eth-keys>=0.2.0b3,<0.3.0` which conflicts with 
eth-keyfile `install_requires`, see:
https://github.com/ethereum/eth-account/blob/v0.3.0/setup.py#L50

### How was it fixed?
Simply updating the upper boundary.


#### Cute Animal Picture

Source: https://www.reddit.com/r/aww/comments/9ss1jf/got_her_to_sit_still_for_5_of_a_second/
![image](https://user-images.githubusercontent.com/24973/47811034-0d466800-dd45-11e8-9c46-48eea0e11d42.png)
