### PR TITLE
Drops python3.4 support

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist=
-    py{34,35,36}
+    py{35,36}
     flake8
 
 [flake8]
@@ -15,7 +15,6 @@ deps =
     -r{toxinidir}/requirements-dev.txt
     py34: typing
 basepython =
-    py34: python3.4
     py35: python3.5
     py36: python3.6
 


### PR DESCRIPTION
### What was wrong?

Python 3.4 is not supported by some of the deps e.g. `eth-hash`.
https://github.com/ethereum/eth-hash/commit/d83db8d1edc5681307970ad2ee7a759a55007e6e

See logs below:
```
Collecting eth-hash<1.0.0,>=0.1.0 (from eth-utils<2.0.0,>=1.0.0-beta.1->eth-keyfile==0.5.1)
  Downloading https://files.pythonhosted.org/packages/0d/d8/0f0c8d4ccaa4c8d25524fd1ed9f5c6d9551b52b74b973f338de3f0a23111/eth_hash-0.2.0-py3-none-any.whl
eth-hash requires Python '>=3.5, <4' but the running Python is 3.4.6
```

### How was it fixed?
Also dropping the support in tox testing.


#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/24973/47811696-ad50c100-dd46-11e8-9f95-2f39650d675a.png)
