### PR TITLE
Allow eth-keys versions >=0.3, <0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import (
 deps = {
     'keyfile': [
         "eth-utils>=1.3.0,<2",
-        "eth-keys>=0.2.1,<0.3.0",
+        "eth-keys>=0.2.1,<0.4.0",
         "pycryptodome>=3.6.6,<4",
     ],
     'test': [


### PR DESCRIPTION
### What was wrong?

Version conflict with https://github.com/ethereum/trinity/pull/586

#### Cute Animal Picture
![Cute animal picture](https://user-images.githubusercontent.com/29854669/59089505-94c30d80-890a-11e9-86be-61d402c2cf6e.jpg)

