### PR TITLE
Change salt size

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ returns the parsed keyfile json as a python dictionary.
 ```
 
 
-### `eth_keyfile.create_keyfile_json(private_key, password, kdf="pbkdf2", work_factor=None) --> keyfile_json`
+### `eth_keyfile.create_keyfile_json(private_key, password, kdf="pbkdf2", work_factor=None, salt_size=16) --> keyfile_json`
 
 Takes the following parameters:
 
@@ -107,6 +107,7 @@ Takes the following parameters:
 * `password`: A bytestring which will be the password that can be used to decrypt the resulting keyfile.
 * `kdf`: The key derivation function.  Allowed values are `pbkdf2` and `scrypt`.  By default, `pbkdf2` will be used.
 * `work_factor`: The work factor which will be used for the given key derivation function.  By default `1000000` will be used for `pbkdf2` and `262144` for `scrypt`.
+* `salt_size`: Salt size in bytes.
 
 Returns the keyfile json as a python dictionary.
 

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -35,9 +35,9 @@ def load_keyfile(path_or_file_obj):
         return json.load(path_or_file_obj)
 
 
-def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2", iterations=None):
+def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2", iterations=None, salt_size=16):
     if version == 3:
-        return _create_v3_keyfile_json(private_key, password, kdf, iterations)
+        return _create_v3_keyfile_json(private_key, password, kdf, iterations, salt_size)
     else:
         raise NotImplementedError("Not yet implemented")
 
@@ -82,8 +82,8 @@ SCRYPT_R = 1
 SCRYPT_P = 8
 
 
-def _create_v3_keyfile_json(private_key, password, kdf, work_factor=None):
-    salt = Random.get_random_bytes(32)
+def _create_v3_keyfile_json(private_key, password, kdf, work_factor=None, salt_size=16):
+    salt = Random.get_random_bytes(salt_size)
 
     if work_factor is None:
         work_factor = get_default_work_factor_for_kdf(kdf)

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -36,10 +36,14 @@ def load_keyfile(path_or_file_obj):
 
 
 def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2",
-        iterations=None, salt_size=16):
+                        iterations=None, salt_size=16):
     if version == 3:
-        return _create_v3_keyfile_json(private_key, password, kdf,
-            iterations, salt_size)
+        return _create_v3_keyfile_json(
+            private_key,
+            password,
+            kdf,
+            iterations,
+            salt_size)
     else:
         raise NotImplementedError("Not yet implemented")
 
@@ -84,8 +88,8 @@ SCRYPT_R = 1
 SCRYPT_P = 8
 
 
-def _create_v3_keyfile_json(private_key, password, kdf,work_factor=None,
-        salt_size=16):
+def _create_v3_keyfile_json(private_key, password, kdf,
+                            work_factor=None, salt_size=16):
     salt = Random.get_random_bytes(salt_size)
 
     if work_factor is None:

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -83,7 +83,7 @@ SCRYPT_P = 8
 
 
 def _create_v3_keyfile_json(private_key, password, kdf, work_factor=None):
-    salt = Random.get_random_bytes(16)
+    salt = Random.get_random_bytes(32)
 
     if work_factor is None:
         work_factor = get_default_work_factor_for_kdf(kdf)

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -35,9 +35,11 @@ def load_keyfile(path_or_file_obj):
         return json.load(path_or_file_obj)
 
 
-def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2", iterations=None, salt_size=16):
+def create_keyfile_json(private_key, password, version=3, kdf="pbkdf2",
+        iterations=None, salt_size=16):
     if version == 3:
-        return _create_v3_keyfile_json(private_key, password, kdf, iterations, salt_size)
+        return _create_v3_keyfile_json(private_key, password, kdf,
+            iterations, salt_size)
     else:
         raise NotImplementedError("Not yet implemented")
 
@@ -82,7 +84,8 @@ SCRYPT_R = 1
 SCRYPT_P = 8
 
 
-def _create_v3_keyfile_json(private_key, password, kdf, work_factor=None, salt_size=16):
+def _create_v3_keyfile_json(private_key, password, kdf,work_factor=None,
+        salt_size=16):
     salt = Random.get_random_bytes(salt_size)
 
     if work_factor is None:

--- a/tests/test_keyfile_creation.py
+++ b/tests/test_keyfile_creation.py
@@ -23,6 +23,18 @@ def test_pbkdf2_keyfile_creation():
     assert derived_private_key == PRIVATE_KEY
 
 
+def test_pbkdf2_keyfile_salt32_creation():
+    keyfile_json = create_keyfile_json(
+        PRIVATE_KEY,
+        password=PASSWORD,
+        kdf='pbkdf2',
+        iterations=1,
+        salt_size=32
+    )
+    derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
+    assert derived_private_key == PRIVATE_KEY
+
+
 def test_scrypt_keyfile_creation():
     keyfile_json = create_keyfile_json(
         PRIVATE_KEY,

--- a/tests/test_keyfile_creation.py
+++ b/tests/test_keyfile_creation.py
@@ -29,8 +29,9 @@ def test_pbkdf2_keyfile_salt32_creation():
         password=PASSWORD,
         kdf='pbkdf2',
         iterations=1,
-        salt_size=32
+        salt_size=32,
     )
+    assert len(keyfile_json['crypto']['kdfparams']['salt']) == 32 * 2
     derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
     assert derived_private_key == PRIVATE_KEY
 


### PR DESCRIPTION
### What was wrong?

Parity does not accept keyfile with 16 bytes salt, it requires 32 bytes.

### How was it fixed?

Raise salt size from 16 to 32 bytes

#### Cute Animal Picture

![Cute animal picture]()