### PR TITLE
Add support for python 3.7-3.10, Drop python 3.5, 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-core
+  py310-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-core
 
   py36-lint:
     <<: *common
@@ -99,6 +105,12 @@ jobs:
       - image: circleci/python:3.9
         environment:
           TOXENV: py39-lint
+  py310-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.10
+        environment:
+          TOXENV: py310-lint
 
 
 workflows:
@@ -109,8 +121,10 @@ workflows:
       - py37-core
       - py38-core
       - py39-core
+      - py310-core
 
       - py36-lint
       - py37-lint
       - py38-lint
       - py39-lint
+      - py310-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-core
+  py37-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-core
 
   py36-lint:
     <<: *common
@@ -63,6 +69,12 @@ jobs:
       - image: circleci/python:3.6
         environment:
           TOXENV: py36-lint
+  py37-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.7
+        environment:
+          TOXENV: py37-lint
 
 
 workflows:
@@ -70,5 +82,7 @@ workflows:
   test:
     jobs:
       - py36-core
+      - py37-core
 
       - py36-lint
+      - py37-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,6 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py35-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-core
   py36-core:
     <<: *common
     docker:
@@ -63,12 +57,6 @@ jobs:
         environment:
           TOXENV: py36-core
 
-  py35-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.5
-        environment:
-          TOXENV: py35-lint
   py36-lint:
     <<: *common
     docker:
@@ -81,8 +69,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - py35-core
       - py36-core
 
-      - py35-lint
       - py36-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,6 +68,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-core
+  py39-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-core
 
   py36-lint:
     <<: *common
@@ -87,6 +93,12 @@ jobs:
       - image: circleci/python:3.8
         environment:
           TOXENV: py38-lint
+  py39-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.9
+        environment:
+          TOXENV: py39-lint
 
 
 workflows:
@@ -96,7 +108,9 @@ workflows:
       - py36-core
       - py37-core
       - py38-core
+      - py39-core
 
       - py36-lint
       - py37-lint
       - py38-lint
+      - py39-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-core
+  py38-core:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-core
 
   py36-lint:
     <<: *common
@@ -75,6 +81,12 @@ jobs:
       - image: circleci/python:3.7
         environment:
           TOXENV: py37-lint
+  py38-lint:
+    <<: *common
+    docker:
+      - image: circleci/python:3.8
+        environment:
+          TOXENV: py38-lint
 
 
 workflows:
@@ -83,6 +95,8 @@ workflows:
     jobs:
       - py36-core
       - py37-core
+      - py38-core
 
       - py36-lint
       - py37-lint
+      - py38-lint

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,12 +50,6 @@ common: &common
         key: cache-v1-{{ arch }}-{{ .Environment.CIRCLE_JOB }}-{{ checksum "setup.py" }}-{{ checksum "tox.ini" }}
 
 jobs:
-  py36-core:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-core
   py37-core:
     <<: *common
     docker:
@@ -81,12 +75,6 @@ jobs:
         environment:
           TOXENV: py310-core
 
-  py36-lint:
-    <<: *common
-    docker:
-      - image: circleci/python:3.6
-        environment:
-          TOXENV: py36-lint
   py37-lint:
     <<: *common
     docker:
@@ -117,13 +105,11 @@ workflows:
   version: 2
   test:
     jobs:
-      - py36-core
       - py37-core
       - py38-core
       - py39-core
       - py310-core
 
-      - py36-lint
       - py37-lint
       - py38-lint
       - py39-lint

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,6 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -71,5 +71,6 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ deps = {
         "pytest>=6.2.5,<7",
     ],
     'lint': [
-        "flake8==3.5.0",
+        "flake8==4.0.1",
     ],
     'dev': [
         "bumpversion>=0.5.3,<1",
@@ -72,5 +72,6 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -74,5 +74,6 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -69,10 +69,7 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ from setuptools import (
 
 deps = {
     'keyfile': [
-        "eth-utils>=1.3.0,<2",
-        "eth-keys>=0.2.1,<0.3.0",
+        "eth-utils>=2,<3",
+        "eth-keys>=0.4.0,<0.5.0",
         "pycryptodome>=3.6.6,<4",
     ],
     'test': [
-        "pytest>=3.6,<3.7",
+        "pytest>=6.2.5,<7",
     ],
     'lint': [
         "flake8==3.5.0",
@@ -23,8 +23,7 @@ deps = {
         "bumpversion>=0.5.3,<1",
         "wheel",
         "setuptools>=36.2.0",
-        # Fixing this dependency due to: pytest 3.6.4 has requirement pluggy<0.8,>=0.5, but you'll have pluggy 0.8.0 which is incompatible.
-        "pluggy==0.7.1",
+        "pluggy>=1.0.0,<2",
         # Fixing this dependency due to: requests 2.20.1 has requirement idna<2.8,>=2.5, but you'll have idna 2.8 which is incompatible.
         "idna==2.7",
         # idna 2.7 is not supported by requests 2.18

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38}-core
-    py{36,37,38}-lint
+    py{36,37,38,39}-core
+    py{36,37,38,39}-lint
 
 [flake8]
 max-line-length= 100
@@ -17,3 +17,4 @@ basepython =
     py36: python3.6
     py37: python3.7
     py38: python3.8
+    py39: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37}-core
-    py{36,37}-lint
+    py{36,37,38}-core
+    py{36,37,38}-lint
 
 [flake8]
 max-line-length= 100
@@ -16,3 +16,4 @@ commands=
 basepython =
     py36: python3.6
     py37: python3.7
+    py38: python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36}-core
-    py{36}-lint
+    py{36,37}-core
+    py{36,37}-lint
 
 [flake8]
 max-line-length= 100
@@ -15,3 +15,4 @@ commands=
     lint: flake8 {toxinidir}/eth_keyfile {toxinidir}/tests
 basepython =
     py36: python3.6
+    py37: python3.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,39,310}-core
-    py{36,37,38,39,310}-lint
+    py{37,38,39,310}-core
+    py{37,38,39,310}-lint
 
 [flake8]
 max-line-length= 100
@@ -14,7 +14,6 @@ commands=
     core: py.test {posargs:tests}
     lint: flake8 {toxinidir}/eth_keyfile {toxinidir}/tests
 basepython =
-    py36: python3.6
     py37: python3.7
     py38: python3.8
     py39: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{36,37,38,39}-core
-    py{36,37,38,39}-lint
+    py{36,37,38,39,310}-core
+    py{36,37,38,39,310}-lint
 
 [flake8]
 max-line-length= 100
@@ -18,3 +18,4 @@ basepython =
     py37: python3.7
     py38: python3.8
     py39: python3.9
+    py310: python3.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=
-    py{35,36}-core
-    py{35,36}-lint
+    py{36}-core
+    py{36}-lint
 
 [flake8]
 max-line-length= 100
@@ -14,5 +14,4 @@ commands=
     core: py.test {posargs:tests}
     lint: flake8 {toxinidir}/eth_keyfile {toxinidir}/tests
 basepython =
-    py35: python3.5
     py36: python3.6


### PR DESCRIPTION
### What was wrong?

Needed to update these dependencies to work with upstream libraries.


### How was it fixed?

Adds support for python 3.7-3.10
Drops support for python 3.5 and 3.6
Updated dependencies so everything resolves

#### Cute Animal Picture

![Cute animal picture](https://lh3.googleusercontent.com/proxy/Uv481PdCSPGu2_fXwgRdPoGbeTvPBaBeb-FOMEO2_sPWuiKgD-8otdDroy2Kx1a-6paF30R7N3lphEpAUQy1l2iEXPtpBByOOISr05XBbL2HMZ6buHfqufu8J8T-_frQi7GRrCY)
