### PR TITLE
Use twine to upload dist files to Pypi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ release: clean
 	git config commit.gpgSign true
 	bumpversion $(bump)
 	git push upstream && git push upstream --tags
-	python setup.py sdist bdist_wheel upload
+	python setup.py sdist bdist_wheel
+	twine upload dist/*
 	git config commit.gpgSign "$(CURRENT_SIGN_SETTING)"
 
 sdist: clean


### PR DESCRIPTION
### What was wrong?

The line `python setup.py sdist bdist_wheel upload` didn't succeed when running the latest release. I suspect I'm missing an API key in my environment, but was feeling too lazy to actually check :)

### How was it fixed?

Added a twine step like our other libraries. This triggers a username/password request. 

#### Cute Animal Picture

![Cute animal picture](https://www.davpetlovers.com/wp-content/uploads/2020/04/IMG_8917-1.jpg)
