### PR TITLE
Use checksum address in keyfile JSON instead of normalized address.

### DIFF
--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -133,7 +133,7 @@ def _create_v3_keyfile_json(private_key, password, kdf,
     ciphertext = encrypt_aes_ctr(private_key, encrypt_key, iv)
     mac = keccak(derived_key[16:32] + ciphertext)
 
-    address = keys.PrivateKey(private_key).public_key.to_address()
+    address = keys.PrivateKey(private_key).public_key.to_checksum_address()
 
     return {
         'address': remove_0x_prefix(address),

--- a/tests/test_keyfile_creation.py
+++ b/tests/test_keyfile_creation.py
@@ -54,4 +54,4 @@ def test_scrypt_keyfile_address():
         kdf='scrypt',
         iterations=2,
     )
-    assert keyfile_json['address'] == '008aeeda4d805471df9b2a5b0f38a0c3bcba786b'
+    assert keyfile_json['address'] == '008AeEda4D805471dF9b2A5B0f38A0C3bCBA786b'


### PR DESCRIPTION
### What was wrong?

When using the address stored in the keyfile, web3.py raises an `InvalidAddress` exception: "Web3.py only accepts checksum addresses.  The software that gave you this non-checksum address should be considered unsafe."

While the address could be converted to a checksum address *after* reading the keyfile, it seems slightly computationally intensive, and could be done *just once* when creating the keyfile.

This is handy because the address can be retrieved and used from the keyfile_json contents without decryption.

### How was it fixed?

Modified `_create_v3_keyfile_json` to use the checksum address instead of the normalized address.  Also modified the corresponding test.  I've assumed (maybe incorrectly) that this would not violate the file specification.

#### Cute Animal Picture

![Cute animal picture](https://i.insider.com/5e74de0b235c1801f042b048?width=1000&format=jpeg&auto=webp)
