### PR TITLE
set valid scrypt work factor

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Unreleased
 -----
 
 - removed deprecated `setuptools-markdown` dependency (https://github.com/ethereum/eth-keyfile/pull/37)
+- set default scrypt work factor to 2^15 (https://github.com/ethereum/eth-keyfile/pull/38)
 
 0.6.0
 -----

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -271,6 +271,8 @@ def get_default_work_factor_for_kdf(kdf):
     if kdf == 'pbkdf2':
         return 1000000
     elif kdf == 'scrypt':
-        return 262144
+        # Per scrypt spec, this should be a power of 2 and less than 2^16 when r=1
+        # This sets it to 2^15
+        return 32768
     else:
         raise ValueError("Unsupported key derivation function: {0}".format(kdf))


### PR DESCRIPTION
### What was wrong?
Default scrypt work factor was set to 2^18. Per the [spec](https://www.rfc-editor.org/rfc/rfc7914#page-7), it should be a power of 2 that is less than 2^16 when R=1.

### How was it fixed?
Set default scrypt work factor to 2^15

#### Cute Animal Picture

![image](https://user-images.githubusercontent.com/5199899/194417683-8a510818-0449-4c5f-825a-e279bbc682c2.png)

