### PR TITLE
fix: use recommended scrypt parameter from pycryptodome. ref #39

### DIFF
--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -84,8 +84,8 @@ def normalize_keys(keyfile_json):
 # Version 3 creators
 #
 DKLEN = 32
-SCRYPT_R = 1
-SCRYPT_P = 8
+SCRYPT_R = 8
+SCRYPT_P = 1
 
 
 def _create_v3_keyfile_json(private_key, password, kdf,


### PR DESCRIPTION
### What was wrong?

As is described by https://github.com/ethereum/eth-keyfile/issues/39, it seems that current default scrypt parameter

```
SCRYPT_R = 1
SCRYPT_P = 8
```

is a typo.

### How was it fixed?

Fix the default parameter to 

```
SCRYPT_R = 8
SCRYPT_P = 1
```

#### Cute Animal Picture

![Cute animal picture](https://pic3.zhimg.com/80/v2-3f253c0d60f4e84e3e613dd00e1d868a_720w.webp)
