### PR TITLE
minor updates from the project template

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,14 +3,14 @@ current_version = 0.6.1
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<stage>[^.]*)\.(?P<devnum>\d+))?
-serialize =
+serialize = 
 	{major}.{minor}.{patch}-{stage}.{devnum}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:stage]
 optional_value = stable
 first_value = stable
-values =
+values = 
 	alpha
 	beta
 	stable

--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ chains
 .cache
 .pytest_cache
 
+# pycache
+__pycache__/
+
 # Test output logs
 logs
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-exclude: '.project-template|docs/conf.py'
+exclude: '.project-template|docs/conf.py|.bumpversion.cfg'
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ notes: check-bump
 
 release: check-bump clean
 	# require that upstream is configured for ethereum/eth-keyfile
-	git remote -v | grep "upstream\tgit@github.com:ethereum/eth-keyfile.git (push)\|upstream\thttps://github.com/ethereum/eth-keyfile (push)"
+	@git remote -v | grep -E "upstream\tgit@github.com:ethereum/eth-keyfile.git \(push\)|upstream\thttps://(www.)?github.com/ethereum/eth-keyfile \(push\)"
 	# verify that docs build correctly
 	./newsfragments/validate_files.py is-empty
 	make docs


### PR DESCRIPTION
### What was wrong?

A couple minor updates pulled from the project template, mostly to add `.bumpversion.cfg` to the `pre-commit` exclude list.

I don't think this calls for a newsfragment, can add if requested.

### Todo:

- [x] Clean up commit history

- [x] Add or update documentation related to these changes

- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-keyfile/blob/master/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/ethereum/eth-keyfile/assets/5199899/9272679a-e9ba-4de7-9f81-d0b8e4f0bfb8)
