### PR TITLE
update password arg types, bump and run mypy local

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,11 +43,14 @@ repos:
     -   id: mdformat
         additional_dependencies:
         -   mdformat-gfm
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+-   repo: local
     hooks:
-    -   id: mypy
-        exclude: tests/
+    -   id: mypy-local
+        name: run mypy with all dev dependencies present
+        entry: python -m mypy -p eth_keyfile
+        language: system
+        always_run: true
+        pass_filenames: false
 -   repo: https://github.com/PrincetonUniversity/blocklint
     rev: v0.2.5
     hooks:

--- a/newsfragments/55.breaking.rst
+++ b/newsfragments/55.breaking.rst
@@ -1,0 +1,1 @@
+Update type of ``password`` arg to be ``bytes`` instead of ``str``, bump to ``mypy==1.10.0`` and have it run with all local deps installed

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "build>=0.9.0",
         "bumpversion>=0.5.3",
         "ipython",
+        "mypy==1.10.0",
         "pre-commit>=3.4.0",
         "tox>=4.0.0",
         "twine",

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ allowlist_externals=make,pre-commit
 
 [testenv:py{38,39,310,311,312}-lint]
 deps=pre-commit
+extras=dev
 commands=
     pre-commit install
     pre-commit run --all-files --show-diff-on-failure


### PR DESCRIPTION
Closes #54 

### How was it fixed?
Updated types of the `password` arg as noted in the issue, plus bumped `mypy` to `1.10.0`, set to run locally instead of with the `pre-commit` mirror, and fixed new errors.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keyfile/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/a8ed5b5e-ecf1-49ca-a8ce-4a5a429be8fa)
