### PR TITLE
add create v4 keyfile

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,20 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs
+
+# Build all formats for RTD Downloads - htmlzip, pdf, epub
+formats: all

--- a/README.md
+++ b/README.md
@@ -51,11 +51,14 @@ returns the parsed keyfile json as a python dictionary.
 
 Takes the following parameters:
 
-- `private_key`: A bytestring of length 32
+- `private_key`: A bytestring of length 32. See note below
 - `password`: A bytestring which will be the password that can be used to decrypt the resulting keyfile.
-- `kdf`: The key derivation function.  Allowed values are `pbkdf2` and `scrypt`.  By default, `pbkdf2` will be used.
-- `work_factor`: The work factor which will be used for the given key derivation function.  By default `1000000` will be used for `pbkdf2` and `262144` for `scrypt`.
-- `salt_size`: Salt size in bytes.
+- `version`: An `int` to select the keyfile standard to use. Supported are `3` and `4`. Defaults to `3`.
+- `kdf`: A `str` to select the key derivation function.  Allowed values are `pbkdf2` and `scrypt`.  By default, `pbkdf2` will be used.
+- `iterations`: An `int` to set the work factor which will be used for the given key derivation function.  By default `1000000` will be used for `pbkdf2` and `262144` for `scrypt`.
+- `salt_size`: An `int` to define the size of the randomly-generated salt in bytes. Defaults to `16` for v3 and `32` for v4.
+- `description`: (v4 only) An optional `str` for a user-defined message, generally to be able to tell one keyfile from another. Defaults to an empty string.
+- `path`: (v4 only) An optional `str` to indicate where in the key-tree a key originates from. Defaults to an empty string. See [EIP-2334](https://eips.ethereum.org/EIPS/eip-2334) for more detail.
 
 Returns the keyfile json as a python dictionary.
 
@@ -82,7 +85,51 @@ Returns the keyfile json as a python dictionary.
     "id" : "3198bc9c-6672-5ab3-d995-4942343ae5b6",
     "version" : 3
 }
+
+>>> create_keyfile_json(private_key, b'foo', version=4)
+ {
+    'crypto': {
+        'checksum': {
+            'function': 'sha256',
+            'message': '66a4883a8017c9ef2854acc0c46af6cc8943de5bcf6bb501a2d6a932a91c5333',
+            'params': {}
+        },
+        'cipher': {
+            'function': 'aes-128-ctr',
+            'message': '584fbbc86d65a92c1e0dfcaa3ba46c4790d31382c5dba25c94acfa2ae6e2687d',
+            'params': {
+                'iv': 'f948a84c4072cc3f38c82f6f672fa8a9'
+            }
+        },
+        'kdf': {
+            'function': 'pbkdf2',
+            'message': '',
+            'params': {
+                'c': 1000000,
+                'dklen': 32,
+                'prf': 'hmac-sha256',
+                'salt': 'd0a1d8a34e7b8bdffbe34e1152ee0bcf3dba64c6e1539cf2bce2ef6995061757'
+            }
+        }
+    },
+    'description': '',
+    'path': '',
+    'pubkey': 'aa1a1c26055a329817a5759d877a2795f9499b97d6056edde0eea39512f24e8bc874b4471f0501127abb1ea0d9f68ac1',
+    'uuid': '92c3f383-e8ea-47a1-a1d7-55adccfae8fe',
+    'version': 4}
 ```
+
+> **A note on private keys:**
+> Valid values for private keys are more limited with the keyfile v4 standard.
+>
+> In v3, a valid key must be less than
+> '0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
+> a limit which most users are unlikely to run into.
+>
+> In v4, that value is '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000'.
+>
+> These limits are due to the cryptographic functions used. `secp256k1` is used for v3,
+> while `bls12-381` is used for v4.
 
 ### `eth_keyfile.decode_keyfile_json(keyfile_json, password) --> private_key`
 

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -280,7 +280,6 @@ def _create_v4_keyfile_json(
     description: Optional[str] = None,
     path: Optional[str] = None,
 ) -> Dict[str, Any]:
-    # fill in the blanks
     if work_factor is None:
         work_factor = get_default_work_factor_for_kdf(kdf)
     if salt_size is None:

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -163,7 +163,6 @@ def _create_v3_keyfile_json(
     work_factor: Optional[int] = None,
     salt_size: Optional[int] = None,
 ) -> Dict[str, Any]:
-    # fill in the blanks
     if work_factor is None:
         work_factor = get_default_work_factor_for_kdf(kdf)
     if salt_size is None:

--- a/newsfragments/56.feature.rst
+++ b/newsfragments/56.feature.rst
@@ -1,0 +1,1 @@
+Add the ability to generate v4 keyfiles in accordance with EIP-2335

--- a/setup.py
+++ b/setup.py
@@ -48,8 +48,9 @@ setup(
     url="https://github.com/ethereum/eth-keyfile",
     include_package_data=True,
     install_requires=[
-        "eth-utils>=2",
         "eth-keys>=0.4.0",
+        "eth-utils>=2",
+        "py_ecc>=5.2.0",
         "pycryptodome>=3.6.6,<4",
     ],
     python_requires=">=3.8, <4",

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -124,3 +124,8 @@ KEYFILE_FIXTURES.update(
 @pytest.fixture(params=KEYFILE_FIXTURES.keys())
 def keyfile_data(request):
     return KEYFILE_FIXTURES[request.param]
+
+
+@pytest.fixture
+def v4_keyfile_data():
+    return {"scrypt": SCRYPT_KEYFILE_V4, "pbkdf2": PBKDF2_KEYFILE_V4}

--- a/tests/core/test_keyfile_creation.py
+++ b/tests/core/test_keyfile_creation.py
@@ -1,8 +1,13 @@
+import pytest
+
 from eth_utils import (
     decode_hex,
+    to_bytes,
 )
 
 from eth_keyfile.keyfile import (
+    MAX_V3_PRIVATE_KEY,
+    MAX_V4_PRIVATE_KEY,
     create_keyfile_json,
     decode_keyfile_json,
 )
@@ -12,16 +17,83 @@ PRIVATE_KEY = decode_hex(
 )
 PASSWORD = b"foo"
 
+PRIVATE_KEYS_VALID_FOR_3_AND_4 = [
+    decode_hex("000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"),
+    decode_hex("21eac69b9a52f466bfe9047f0f21c9caf3a5cdaadf84e2750a9b3265d450d481"),
+    to_bytes(MAX_V4_PRIVATE_KEY),
+]
+PRIVATE_KEYS_VALID_FOR_3_NOT_4 = [
+    decode_hex("7a28b5ba57c53603b0b07b56bba752f7784bf506fa95edc395f5cf6c7514fe9d"),
+    decode_hex("deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+]
 
-def test_pbkdf2_keyfile_creation():
+PRIVATE_KEYS_INVALID_FOR_3_AND_4 = [
+    decode_hex("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+    to_bytes(MAX_V3_PRIVATE_KEY + 1),
+]
+
+VALID_V3 = PRIVATE_KEYS_VALID_FOR_3_AND_4 + PRIVATE_KEYS_VALID_FOR_3_NOT_4
+VALID_V4 = PRIVATE_KEYS_VALID_FOR_3_AND_4
+INVALID_V3 = PRIVATE_KEYS_INVALID_FOR_3_AND_4
+INVALID_V4 = PRIVATE_KEYS_VALID_FOR_3_NOT_4 + PRIVATE_KEYS_INVALID_FOR_3_AND_4
+
+
+@pytest.mark.parametrize("private_key", VALID_V3)
+@pytest.mark.parametrize("kdf", ["pbkdf2", "scrypt"])
+@pytest.mark.parametrize("iterations", [1, 2, 4])
+def test_keyfile_v3_creation(private_key, kdf, iterations):
     keyfile_json = create_keyfile_json(
-        PRIVATE_KEY,
+        private_key,
         password=PASSWORD,
-        kdf="pbkdf2",
-        iterations=1,
+        version=3,
+        kdf=kdf,
+        iterations=iterations,
     )
     derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
-    assert derived_private_key == PRIVATE_KEY
+    assert derived_private_key == private_key
+
+
+@pytest.mark.parametrize("private_key", VALID_V4)
+@pytest.mark.parametrize("kdf", ["pbkdf2", "scrypt"])
+@pytest.mark.parametrize("iterations", [1, 2, 4])
+@pytest.mark.parametrize("salt_size", [1, 8, 9, 64, 128])
+@pytest.mark.parametrize("description", ["", "foo", "bar"])
+@pytest.mark.parametrize("path", ["a/b", "m/12381/60/3141592653/589793238"])
+def test_keyfile_v4_creation(
+    private_key, kdf, iterations, salt_size, description, path
+):
+    keyfile_json = create_keyfile_json(
+        private_key,
+        password=PASSWORD,
+        version=4,
+        kdf=kdf,
+        iterations=iterations,
+        salt_size=salt_size,
+        description=description,
+        path=path,
+    )
+    derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
+    assert derived_private_key == private_key
+
+
+@pytest.mark.parametrize("private_key", INVALID_V3)
+def test_invalid_v3_private_key_raises(private_key):
+    with pytest.raises(ValueError):
+        create_keyfile_json(
+            private_key,
+            password=PASSWORD,
+            version=3,
+        )
+
+
+@pytest.mark.parametrize("private_key", INVALID_V4)
+def test_invalid_v4_private_key_raises(private_key):
+    with pytest.raises(ValueError):
+        create_keyfile_json(
+            private_key,
+            password=PASSWORD,
+            version=4,
+        )
 
 
 def test_pbkdf2_keyfile_salt32_creation():
@@ -33,17 +105,6 @@ def test_pbkdf2_keyfile_salt32_creation():
         salt_size=32,
     )
     assert len(keyfile_json["crypto"]["kdfparams"]["salt"]) == 32 * 2
-    derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
-    assert derived_private_key == PRIVATE_KEY
-
-
-def test_scrypt_keyfile_creation():
-    keyfile_json = create_keyfile_json(
-        PRIVATE_KEY,
-        password=PASSWORD,
-        kdf="scrypt",
-        iterations=2,
-    )
     derived_private_key = decode_keyfile_json(keyfile_json, PASSWORD)
     assert derived_private_key == PRIVATE_KEY
 

--- a/tests/core/test_keyfile_creation.py
+++ b/tests/core/test_keyfile_creation.py
@@ -117,3 +117,26 @@ def test_scrypt_keyfile_address():
         iterations=2,
     )
     assert keyfile_json["address"] == "008AeEda4D805471dF9b2A5B0f38A0C3bCBA786b"
+
+
+def recursive_check_dicts(dict1, dict2):
+    for key in dict1:
+        if isinstance(dict1[key], dict):
+            recursive_check_dicts(dict1[key], dict2[key])
+        else:
+            assert type(dict1[key]) is type(dict2[key])
+
+
+@pytest.mark.parametrize("kdf", ["pbkdf2", "scrypt"])
+def test_v4_create_datatypes_match(kdf, v4_keyfile_data):
+    test_pk = v4_keyfile_data[kdf]["priv"]
+    test_pw = v4_keyfile_data[kdf]["password"]
+    new_keyfile = create_keyfile_json(
+        private_key=decode_hex(test_pk),
+        password=test_pw.encode("utf-8"),
+        version=4,
+        kdf=kdf,
+        description=v4_keyfile_data[kdf]["json"]["description"],
+        path=v4_keyfile_data[kdf]["json"]["path"],
+    )
+    recursive_check_dicts(new_keyfile, v4_keyfile_data[kdf]["json"])


### PR DESCRIPTION
### What was wrong?

We can decode a v4 keyfile, but not create one

Closes #26 

### How was it fixed?

Add ability to create the v4 keyfile, plus tests and a note in the docs regarding maximum valid private keys.

Also added a `.readthedocs.yaml` in preparation for moving docs from the README to RTD

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keyfile/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/9d4d1adb-b402-4d7c-b2c4-af5e75d6643e)
