### PR TITLE
Custom exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ returns the parsed keyfile json as a python dictionary.
 
 Takes the following parameters:
 
-- `private_key`: A bytestring of length 32. See note below
+- `private_key`: A bytestring of length 32. [See note below.](#a-note-on-private-keys)
 - `password`: A bytestring which will be the password that can be used to decrypt the resulting keyfile.
 - `version`: An `int` to select the keyfile standard to use. Supported are `3` and `4`. Defaults to `3`.
 - `kdf`: A `str` to select the key derivation function.  Allowed values are `pbkdf2` and `scrypt`.  By default, `pbkdf2` will be used.
@@ -119,14 +119,15 @@ Returns the keyfile json as a python dictionary.
     'version': 4}
 ```
 
-> **A note on private keys:**
+#### A note on private keys
+
 > Valid values for private keys are more limited with the keyfile v4 standard.
 >
 > In v3, a valid key must be less than
-> '0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140',
+> '0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141',
 > a limit which most users are unlikely to run into.
 >
-> In v4, that value is '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000'.
+> In v4, the key must be less than '0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001'.
 >
 > These limits are due to the cryptographic functions used. `secp256k1` is used for v3,
 > while `bls12-381` is used for v4.

--- a/eth_keyfile/exceptions.py
+++ b/eth_keyfile/exceptions.py
@@ -1,0 +1,52 @@
+from typing import (
+    Any,
+    Optional,
+)
+
+
+class EthKeyfileException(Exception):
+    """
+    Exception mixin inherited by all exceptions of eth-keyfile
+
+    This allows::
+
+        try:
+            some_call()
+        except EthKeyfileException:
+            # deal with eth-keyfile exception
+        except:
+            # deal with other exceptions
+    """
+
+    user_message: Optional[str] = None
+
+    def __init__(
+        self,
+        *args: Any,
+        user_message: Optional[str] = None,
+    ):
+        super().__init__(*args)
+
+        # Assign properties of EthKeyfileException
+        self.user_message = user_message
+
+
+class EthKeyfileNotImplementedError(EthKeyfileException, NotImplementedError):
+    """
+    An eth-keyfile exception wrapper for `NotImplementedError`, for better control over
+    exception handling
+    """
+
+
+class EthKeyfileValueError(EthKeyfileException, ValueError):
+    """
+    An eth-keyfile exception wrapper for `ValueError`, for better control over
+    exception handling
+    """
+
+
+class EthKeyfileTypeError(EthKeyfileException, TypeError):
+    """
+    An eth-keyfile exception wrapper for `TypeError`, for better control over
+    exception handling
+    """

--- a/eth_keyfile/keyfile.py
+++ b/eth_keyfile/keyfile.py
@@ -175,7 +175,10 @@ def _create_v3_keyfile_json(
         salt_size = 16
 
     if to_int(private_key) > MAX_V3_PRIVATE_KEY:
-        raise EthKeyfileValueError("Invalid `private_key`, exceeds maximum valid value")
+        raise EthKeyfileValueError(
+            "Invalid `private_key`, exceeds maximum valid secp256k1 key "
+            f"value of {MAX_V3_PRIVATE_KEY}"
+        )
 
     salt = Random.get_random_bytes(salt_size)
 
@@ -298,7 +301,10 @@ def _create_v4_keyfile_json(
     aes_iv = Random.get_random_bytes(16)
 
     if to_int(private_key) > MAX_V4_PRIVATE_KEY:
-        raise EthKeyfileValueError("Invalid `private_key`, exceeds maximum valid value")
+        raise EthKeyfileValueError(
+            "Invalid `private_key`, exceeds maximum valid bls12-381 key "
+            f"value of {MAX_V4_PRIVATE_KEY}"
+        )
 
     salt: bytes = Random.get_random_bytes(salt_size)
     uuid: str = str(uuid4())

--- a/newsfragments/58.feature.rst
+++ b/newsfragments/58.feature.rst
@@ -1,0 +1,1 @@
+Create new ``EthKeyfileException`` and replace currently-used exceptions with ``EthKeyfile`` versions to allow more granular exception handling

--- a/tests/core/test_keyfile_creation.py
+++ b/tests/core/test_keyfile_creation.py
@@ -5,6 +5,9 @@ from eth_utils import (
     to_bytes,
 )
 
+from eth_keyfile.exceptions import (
+    EthKeyfileValueError,
+)
 from eth_keyfile.keyfile import (
     MAX_V3_PRIVATE_KEY,
     MAX_V4_PRIVATE_KEY,
@@ -78,7 +81,7 @@ def test_keyfile_v4_creation(
 
 @pytest.mark.parametrize("private_key", INVALID_V3)
 def test_invalid_v3_private_key_raises(private_key):
-    with pytest.raises(ValueError):
+    with pytest.raises(EthKeyfileValueError):
         create_keyfile_json(
             private_key,
             password=PASSWORD,
@@ -88,7 +91,7 @@ def test_invalid_v3_private_key_raises(private_key):
 
 @pytest.mark.parametrize("private_key", INVALID_V4)
 def test_invalid_v4_private_key_raises(private_key):
-    with pytest.raises(ValueError):
+    with pytest.raises(EthKeyfileValueError):
         create_keyfile_json(
             private_key,
             password=PASSWORD,

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,62 @@
+import os
+import pytest
+
+from eth_keyfile.exceptions import (
+    EthKeyfileException,
+)
+
+
+def test_ethkeyfileexception_with_user_message():
+    with pytest.raises(EthKeyfileException) as exception:
+        raise EthKeyfileException(user_message="This failed!")
+    assert exception.type is EthKeyfileException
+    assert exception.value.user_message == "This failed!"
+
+
+def test_ethkeyfileexception_with_kwargs():
+    with pytest.raises(TypeError) as exception:
+        raise EthKeyfileException(data={"message": "Unable to fulfill your request."})
+
+    # For Python > 3.9, str exception includes 'EthKeyfileException.'
+    expected = "__init__() got an unexpected keyword argument 'data'"
+    actual = str(exception.value)
+    assert exception.type is TypeError
+    assert hasattr(exception.value, "data") is False
+    assert expected in actual
+
+
+def test_ethkeyfileexception_with_args():
+    with pytest.raises(EthKeyfileException) as exception:
+        raise EthKeyfileException("failed")
+    assert exception.type is EthKeyfileException
+    assert exception.value.user_message is None
+    assert exception.value.args[0] == "failed"
+
+
+ETH_KEYFILE_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "..", "eth_keyfile"
+)
+DEFAULT_EXCEPTIONS = (
+    NotImplementedError,
+    TypeError,
+    ValueError,
+)
+
+
+def test_no_default_exceptions_are_raised_within_py_geth():
+    for root, _dirs, files in os.walk(ETH_KEYFILE_PATH):
+        for file in files:
+            if file.endswith(".py"):
+                file_path = os.path.join(root, file)
+                with open(file_path, encoding="utf-8") as f:
+                    for idx, line in enumerate(f):
+                        for exception in DEFAULT_EXCEPTIONS:
+                            exception_name = exception.__name__
+                            if f"raise {exception_name}" in line:
+                                raise Exception(
+                                    f"``{exception_name}`` raised in eth-keyfile file "
+                                    f"``{file}``, line {idx + 1}. "
+                                    f"Replace with ``EthKeyfile{exception_name}``:\n"
+                                    f"    file_path:{file_path}\n"
+                                    f"    line:{idx + 1}"
+                                )


### PR DESCRIPTION
### What was wrong?

We're moving to creating unique exception types for each lib to allow more granular exception handling.

Closes #24 

### How was it fixed?

Created new `EthKeyfileException` and based currently-used error types off of it.

Noticed that the max key values were off by one, fixed that.

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keyfile/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![image](https://github.com/user-attachments/assets/33b4d286-377f-4c2b-b16b-5f2b49eaf17f)
